### PR TITLE
[docs fix] Missing `,`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ var stuff = {
     "json",
     "interacive",
     "prompt"
-  ]
+  ],
   "foo": function() { 
     return "node tests/test.js"
   }


### PR DESCRIPTION
Error in docs
