### PR TITLE
Using arrow keys in search mode will throw a type error

### DIFF
--- a/cdir.js
+++ b/cdir.js
@@ -503,7 +503,7 @@ var listener = function listener (chunk, key) {
     //
     return true;
   }
-  else if (searchmode === true) {
+  else if (searchmode === true && typeof(chunk) !== 'undefined') {
     
     write(chunk);
     searchbuffer += chunk;


### PR DESCRIPTION
I noticed this while playing around with search mode earlier. Making sure chunk is not undefined resolves the problem.
