### PR TITLE
Search mode duplication

### DIFF
--- a/cdir.js
+++ b/cdir.js
@@ -553,7 +553,7 @@ var listener = function listener (chunk, key) {
       toggle(index);
     }
 
-    if (key.name === 'q' || key.ctrl && key.name === 'q') {
+    if (key.name === 'q' || key.ctrl && key.name === 'c') {
       stdin.removeListener('keypress', listener);
       stdin.pause();
     }


### PR DESCRIPTION
I noticed that if you're in search mode and you have a previous search term in the parentheses

`(term) /`

Pressing slash again will cause duplicates:

`(term) /(term) /(term) /(term) /(term) /`

I imagine use cases for functionality like this, but in this case pressing slash in search mode activates search mode again in addition to preventing '/' from being searchable.

Checking to see if searchmode is already active takes care of this.
