### PR TITLE
Return control to node standard stdin/stdout

### DIFF
--- a/cdir.js
+++ b/cdir.js
@@ -638,8 +638,8 @@ module.exports = function dir (obj, options) {
         else {
           stdin.pause();
         }
-
         stdin.removeListener('keypress', listener);
+        tty.setRawMode(false);
       }
 
     }


### PR DESCRIPTION
On exit Windows console gets stuck without this  (not tested on linux)
